### PR TITLE
Fix magic method deprecation warning

### DIFF
--- a/index.php
+++ b/index.php
@@ -56,7 +56,7 @@ if ($data = $form->get_data()) {
         if ($error) {
             $form->set_import_error($error);
         } else {
-            redirect(new moodle_url('continue.php', array('id' => $framework->get_id())));
+            redirect(new moodle_url('continue.php', array('id' => $framework->get('id'))));
             die();
         }
     }


### PR DESCRIPTION
Fix magic method warning:

Use of magic setters and getters is deprecated. Use get() and set().
line 57 of /competency/classes/persistent.php: call to debugging()